### PR TITLE
Change = to : in the example so it actually works

### DIFF
--- a/sample.js
+++ b/sample.js
@@ -1,4 +1,4 @@
-var vertexShader = ` // glsl
+var vertexShader: ` // glsl
   attribute vec3 position;
   attribute float time;
 
@@ -12,7 +12,7 @@ var vertexShader = ` // glsl
   }
 `
 
-var fragmentShader = `//glsl
+var fragmentShader: `// glsl
   varying float age;
   void main() {
     if (age < 0) { discard; }


### PR DESCRIPTION
We're explicitly looking for ":" with `(vertexShader|fragmentShader)\\s*(:)\\s*(`)`, so the example file should probably reflect that.